### PR TITLE
fix: turn-off import rule

### DIFF
--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -8,6 +8,7 @@ const baseConfig = [
       'style/function-call-spacing': ['error', 'never'],
       'node/prefer-global/process': 'off',
       'antfu/top-level-function': 'off',
+      'perfectionist/sort-imports': 'off',
     },
   },
 


### PR DESCRIPTION
Antfu's config https://github.com/antfu/eslint-config recently added `perfectionist` plugin for eslint here https://github.com/antfu/eslint-config/commit/a6efa0957a6189001b85d1a1d68a90511dae2022

This is causing a lot of issues in our projects and a lot of noise. This PR turns off `perfectionist/sort-imports` which collides with the normal autofix